### PR TITLE
Add mock posts to feed with styled post cards

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -16,6 +16,7 @@
     "framer-motion": "^12.18.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-icons": "^5.5.0",
     "react-router-dom": "^7.6.2"
   },
   "devDependencies": {

--- a/apps/frontend/src/mock/posts.ts
+++ b/apps/frontend/src/mock/posts.ts
@@ -1,0 +1,27 @@
+export type Post = {
+  id: number;
+  title: string;
+  content: string;
+  author: string;
+  createdAt: string;
+  upvotes: number;
+};
+
+export const mockPosts: Post[] = [
+  {
+    id: 1,
+    title: 'Welcome to Operative Tortoise!',
+    content: 'This is the very first post. Say hi to the community!',
+    author: 'admin',
+    createdAt: new Date().toISOString(),
+    upvotes: 15,
+  },
+  {
+    id: 2,
+    title: 'What feature should we build next?',
+    content: 'Drop your thoughts below ⬇️',
+    author: 'johndoe',
+    createdAt: new Date().toISOString(),
+    upvotes: 8,
+  },
+];

--- a/apps/frontend/src/pages/Feed.tsx
+++ b/apps/frontend/src/pages/Feed.tsx
@@ -5,9 +5,13 @@ import {
   Stack,
   Image,
   Button,
+  Badge,
+  IconButton,
 } from '@chakra-ui/react';
+import { BiSolidUpvote } from "react-icons/bi";
 import { useAuth } from '../context/AuthContext';
 import { useNavigate } from 'react-router-dom';
+import { mockPosts } from '../mock/posts'; // <-- NEW IMPORT
 
 const Feed = () => {
   const { user, logout } = useAuth();
@@ -28,6 +32,7 @@ const Feed = () => {
         mx="auto"
         p={6}
         textAlign="center"
+        mb={8}
       >
         <Box
           w="96px"
@@ -59,14 +64,32 @@ const Feed = () => {
         <Stack gap={4} align="center">
           <Heading size="md">Hello, {user?.username} 👋</Heading>
           <Text color="gray.600">Welcome to your feed.</Text>
-          <Button
-            onClick={handleLogout}
-            colorScheme="red"
-            variant="solid"
-            size="sm"
-          >
+          <Button onClick={handleLogout} colorScheme="red" size="sm">
             Logout
           </Button>
+        </Stack>
+      </Box>
+
+      <Box maxW="xl" mx="auto">
+        <Stack>
+          {mockPosts.map((post) => (
+            <Box key={post.id} p={6} bg="white" rounded="md" shadow="sm">
+              <Heading size="sm" mb={2}>
+                {post.title}
+              </Heading>
+              <Text mb={3}>{post.content}</Text>
+              <Stack direction="row" justify="space-between" fontSize="sm" color="gray.500">
+                <Text>by {post.author}</Text>
+                <Text>{new Date(post.createdAt).toLocaleString()}</Text>
+              </Stack>
+              <Stack mt={3} direction="row" align="center">
+                <IconButton size="xs" aria-label="Upvote" variant="ghost">
+                  <BiSolidUpvote/>
+                </IconButton>
+                <Badge colorScheme="blue">{post.upvotes}</Badge>
+              </Stack>
+            </Box>
+          ))}
         </Stack>
       </Box>
     </Box>

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "framer-motion": "^12.18.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.2"
       },
       "devDependencies": {
@@ -5143,6 +5144,14 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-icons": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.5.0.tgz",
+      "integrity": "sha512-MEFcXdkP3dLo8uumGI5xN3lDFNsRtrjbOEKDLD7yv76v4wpnEq2Lt2qeHaQOr34I/wPN3s3+N08WkQ+CW37Xiw==",
+      "peerDependencies": {
+        "react": "*"
       }
     },
     "node_modules/react-is": {


### PR DESCRIPTION
Add mock feed data and display it on the Feed page with styled post cards using Chakra UI. Created a separate mock/posts.ts file and integrated it into the feed. Posts include title, content, author, upvotes, and timestamps.