### PR TITLE
feat: add password change page and navigation from profile

### DIFF
--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -29,4 +29,41 @@ router.get('/profile/:id', async (req, res) => {
   });
 });
 
+router.put('/profile/:id/password', async (req, res) => {
+  const userId = (req.params.id);
+  const { currentPassword, newPassword } = req.body;
+
+  if (!currentPassword || !newPassword) {
+    res.status(400).json({ error: 'Both current and new passwords are required' });
+    return;
+  }
+
+  try {
+    const user = await prisma.user.findUnique({ where: { id: userId } });
+    if (!user) {
+        res.status(404).json({ error: 'User not found' });
+        return;
+    } 
+
+    if (user.password !== currentPassword) {
+      res.status(401).json({ error: 'Current password is incorrect' });
+      return;
+    }
+
+    await prisma.user.update({
+      where: { id: userId },
+      data: { password: newPassword },
+    });
+
+    res.json({ success: true, message: 'Password updated successfully' });
+    return 
+
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+    return ;
+  }
+});
+
+
 export default router;

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Register from './pages/Register';
 import NewPost from './pages/NewPost'
 import EditPost from './pages/EditPost';
 import Profile from './pages/Profile';
+import ChangePassword from './pages/ChangePassword';
 
 function App() {
   return (
@@ -23,9 +24,10 @@ function App() {
               </PrivateRoute>
             }
           />
-          <Route path="/new" element={<NewPost />} />
-          <Route path="/edit/:id" element={<EditPost />} />
-          <Route path="/profile" element={<Profile />} />
+          <Route path="/new" element={<PrivateRoute><NewPost /></PrivateRoute>} />
+          <Route path="/edit/:id" element={<PrivateRoute><EditPost /></PrivateRoute>} />
+          <Route path="/profile" element={<PrivateRoute><Profile /></PrivateRoute>} />
+          <Route path="/change-password" element={<PrivateRoute><ChangePassword /></PrivateRoute>} />
         </Routes>
       </Router>
     </AuthProvider>

--- a/apps/frontend/src/pages/ChangePassword.tsx
+++ b/apps/frontend/src/pages/ChangePassword.tsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import {
+  Box,
+  Heading,
+  Input,
+  Button,
+  Stack
+} from "@chakra-ui/react";
+import { useAuth } from "../context/AuthContext";
+import { useNavigate } from "react-router-dom";
+import { toaster } from "../components/ui/toaster";
+
+const ChangePassword = () => {
+  const [currentPassword, setCurrentPassword] = useState("");
+  const [newPassword, setNewPassword] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { user } = useAuth();
+  const navigate = useNavigate();
+
+  const handleChangePassword = async () => {
+    if (!currentPassword || !newPassword) {
+      toaster.create({
+        title: "All fields are required",
+        type: "error",
+        closable: true,
+        duration: 2000,
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const res = await fetch(`http://localhost:3001/api/profile/${user?.id}/password`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ currentPassword, newPassword }),
+      });
+
+      const data = await res.json();
+
+      if (!res.ok) {
+        toaster.create({
+          title: data.error || "Failed to update password",
+          type: "error",
+          closable: true,
+          duration: 2000,
+        });
+        return;
+      }
+
+      toaster.create({
+        title: "Password updated successfully",
+        type: "success",
+        closable: true,
+        duration: 2000,
+      });
+
+      navigate("/profile");
+
+    } catch (err) {
+      console.error(err);
+      toaster.create({
+        title: "Something went wrong",
+        type: "error",
+        closable: true,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Box maxW="md" mx="auto" mt={10} p={6} bg="white" rounded="md" shadow="md">
+      <Heading size="md" mb={4}>Change Password</Heading>
+      <Stack spaceX={4}>
+        <Input
+          placeholder="Current Password"
+          type="password"
+          value={currentPassword}
+          onChange={(e) => setCurrentPassword(e.target.value)}
+        />
+        <Input
+          placeholder="New Password"
+          type="password"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+        />
+        <Button
+          colorScheme="teal"
+          onClick={handleChangePassword}
+          loading={isSubmitting}
+        >
+          Update Password
+        </Button>
+        <Button variant="ghost" onClick={() => navigate("/profile")}>
+          Cancel
+        </Button>
+      </Stack>
+    </Box>
+  );
+};
+
+export default ChangePassword;


### PR DESCRIPTION
This PR introduces a new page (/change-password) allowing users to update their password from the profile section. The page provides inputs for the current and new passwords, handles validation, and communicates with the backend via a PUT request. A success or error toast is shown based on the server response. Navigation is wired from the profile page, and routing is updated accordingly.

