### PR TITLE
Fix Profile Page: Add API to fetch user posts and integrate with frontend

### DIFF
--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -78,7 +78,6 @@ router.get('/posts', async (_req, res) => {
 
 router.get('/posts/:id', async (req, res) => {
   const id = req.params.id;
-
   try {
     const posts = await prisma.post.findMany({
       where: { id: Number(id) },

--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -29,6 +29,32 @@ router.get('/profile/:id', async (req, res) => {
   });
 });
 
+
+//Get all posts of a particular User
+router.get('/profile/:id/posts', async (req, res) => {
+  const id = req.params.id;
+
+  try {
+    const posts = await prisma.post.findMany({
+      where: { authorId: id },
+      select: {
+        id: true,
+        title: true,
+        content: true,
+        updatedAt: true,
+      },
+      orderBy: {
+        updatedAt: 'desc',
+      },
+    });
+
+    res.json(posts);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch user posts' });
+  }
+});
+
 router.put('/profile/:id/password', async (req, res) => {
   const userId = (req.params.id);
   const { currentPassword, newPassword } = req.body;

--- a/apps/backend/src/routes/users.ts
+++ b/apps/backend/src/routes/users.ts
@@ -5,6 +5,7 @@ const prisma = new PrismaClient();
 const router = express.Router();
 
 router.get('/user/:username', async (req, res) => {
+  console.log("GET request for user profile")
   const { username } = req.params;
 
   try {

--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -36,7 +36,10 @@ const Navbar = () => {
   };
 
   const handleProfileClick = () => {
-    navigate(`/profile/${user?.username}`);
+    console.log("Handle profile clicked");
+    navigate(`/profile/${user?.username}`, {
+      state: { userId: user?.id },
+    });
   };
 
   const handleSettingsClick = () => {

--- a/apps/frontend/src/pages/Feed.tsx
+++ b/apps/frontend/src/pages/Feed.tsx
@@ -137,6 +137,7 @@ const Feed = () => {
                   whileTap={{ scale: 0.98 }}
                   transition={{ type: 'spring', stiffness: 300 }}
                   onClick={() => navigate(`/post/${post.id}`, { state: { post } })}
+                  key={post.id}
                 >
                 <Box 
                   key={post.id} p={6} bg="white" rounded="md" shadow="sm" 

--- a/apps/frontend/src/pages/Profile.tsx
+++ b/apps/frontend/src/pages/Profile.tsx
@@ -22,7 +22,7 @@ interface Post {
   id: string;
   title: string;
   content: string;
-  createdAt: string;
+  updatedAt: string;
 }
 
 const Profile = () => {
@@ -33,7 +33,6 @@ const Profile = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const userId = state?.userId;
-
   useEffect(() => {
     const fetchProfileAndPosts = async () => {
       if (!userId) return;
@@ -54,7 +53,7 @@ const Profile = () => {
     };
 
     fetchProfileAndPosts();
-  }, [userId]);
+  },[userId]);
 
   if (loading) {
     return (
@@ -83,7 +82,7 @@ const Profile = () => {
         <Heading size="md">{profile.name}</Heading>
         <Text fontSize="sm" color="gray.600">{profile.email}</Text>
         <Text>Joined on: <strong>{formattedDate}</strong></Text>
-        <Text>Year: <strong>{joinedYear}</strong></Text>
+        {/* <Text>Year: <strong>{joinedYear}</strong></Text> */}
 
         {user?.id === userId && (
           <Button onClick={() => navigate('/change-password')}>
@@ -93,7 +92,6 @@ const Profile = () => {
         <Button onClick={() => navigate('/feed')}>Back</Button>
       </Stack>
 
-      {/* <Divider my={6} /> */}
 
       <Box>
         <Heading size="md" mb={4}>Posts by {profile.name}</Heading>
@@ -104,7 +102,7 @@ const Profile = () => {
             <Box key={post.id} p={4} mb={4} borderWidth="1px" borderRadius="md">
               <Heading size="sm">{post.title}</Heading>
               <Text fontSize="sm" color="gray.600">
-                {new Date(post.createdAt).toLocaleDateString()}
+                {new Date(post.updatedAt).toLocaleDateString()}
               </Text>
               <Text mt={2}>{post.content}</Text>
             </Box>


### PR DESCRIPTION
This PR addresses a bug in the Profile page where it attempted to fetch user-specific posts from a non-existent backend route. To resolve this:

✅ Created a new backend route: GET /profile/:id/posts

It returns all posts authored by the user (identified by authorId)

Returns essential post fields: id, title, content, updatedAt

Posts are sorted by most recently updated

✅ Updated the frontend logic in the Profile page to call this new API

✅ The profile now correctly displays a list of all posts authored by the current user