### PR TITLE
Show only other users' posts in Feed page

### DIFF
--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -75,6 +75,32 @@ router.get('/posts', async (_req, res) => {
   }
 });
 
+// Get all posts except those of the logged-in user
+router.get('/other-posts/:userId', async (req, res) => {
+  const { userId } = req.params;
+
+  try {
+    const posts = await prisma.post.findMany({
+      where: {
+        authorId: {
+          not: userId,
+        },
+      },
+      orderBy: { updatedAt: 'desc' },
+      include: {
+        author: {
+          select: { id: true, username: true, avatar: true },
+        },
+      },
+    });
+
+    res.json(posts);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to fetch posts' });
+  }
+});
+
 
 router.get('/posts/:id', async (req, res) => {
   const id = req.params.id;

--- a/apps/frontend/src/pages/Feed.tsx
+++ b/apps/frontend/src/pages/Feed.tsx
@@ -61,7 +61,7 @@ const Feed = () => {
   useEffect(() => {
     const fetchPosts = async () => {
       try {
-        const res = await fetch('http://localhost:3001/api/posts');
+        const res = await fetch(`http://localhost:3001/api/other-posts/${user?.id}`);
         const data = await res.json();
         setAllPosts(data);
       } catch (err) {
@@ -71,8 +71,10 @@ const Feed = () => {
       }
     };
 
-    fetchPosts();
-  }, []);
+    if (user?.id) {
+      fetchPosts();
+    }
+  }, [user?.id]);
 
   useEffect(() => {
     if (filter === 'all') {


### PR DESCRIPTION
- Added new backend API endpoint `/api/other-posts/:userId` to return posts created by users other than the logged-in user.
- Updated the frontend Feed page to call this endpoint using the logged-in user's ID.
- The feed now cleanly separates posts authored by other users from the logged-in user's own posts.
