### PR TITLE
fix: resolve profile page not loading on direct URL access

### DIFF
--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -92,5 +92,23 @@ router.put('/profile/:id/password', async (req, res) => {
   }
 });
 
+router.get('/profile/username-to-id/:username', async (req, res) => {
+  const { username } = req.params;
+  console.log("Here ",username)
+  try {
+    const user = await prisma.user.findUnique({
+      where: { username },
+      select: { id: true }
+    });
+    if (!user) {
+      res.status(404).json({ error: 'User not found' });
+      return;
+    }
+    res.json({ id: user.id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
 
 export default router;

--- a/apps/frontend/src/context/AuthContext.tsx
+++ b/apps/frontend/src/context/AuthContext.tsx
@@ -2,7 +2,7 @@ import { createContext, useContext, useEffect, useState } from 'react';
 import type { ReactNode } from 'react';
 
 type User = {
-  id: number;
+  id: string;
   username: string;
   avatar: string;
 };

--- a/apps/frontend/src/pages/ChangePassword.tsx
+++ b/apps/frontend/src/pages/ChangePassword.tsx
@@ -57,7 +57,7 @@ const ChangePassword = () => {
         duration: 2000,
       });
 
-      navigate("/profile");
+      navigate(`/profile/${user?.username}`);
 
     } catch (err) {
       console.error(err);
@@ -94,7 +94,7 @@ const ChangePassword = () => {
         >
           Update Password
         </Button>
-        <Button variant="ghost" onClick={() => navigate("/profile")}>
+        <Button variant="ghost" onClick={() => navigate(`/profile/${user?.username}`)}>
           Cancel
         </Button>
       </Stack>


### PR DESCRIPTION
This PR fixes an issue where the profile page would hang indefinitely (showing a spinner) when accessed directly via a URL (e.g., /profile/johndoe) or via redirect (e.g., after cancelling password change). The fix involves using useParams to extract the username from the URL and a fallback fetch to resolve the user ID if not passed via location state. A new backend route /api/username-to-id/:username was added to support this resolution.