### PR TITLE
feat: enable edit and delete for user posts in profile page

### DIFF
--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -42,13 +42,13 @@ router.get('/profile/:id/posts', async (req, res) => {
         title: true,
         content: true,
         updatedAt: true,
-        upvotes: true
+        upvotes: true,
+        author:true
       },
       orderBy: {
         createdAt: 'desc',
       },
     });
-
     res.json(posts);
   } catch (err) {
     console.error(err);
@@ -94,7 +94,6 @@ router.put('/profile/:id/password', async (req, res) => {
 
 router.get('/profile/username-to-id/:username', async (req, res) => {
   const { username } = req.params;
-  console.log("Here ",username)
   try {
     const user = await prisma.user.findUnique({
       where: { username },

--- a/apps/frontend/src/pages/Profile.tsx
+++ b/apps/frontend/src/pages/Profile.tsx
@@ -13,8 +13,9 @@ import {
 import { useAuth } from "../context/AuthContext";
 import { useNavigate, useLocation, useParams } from "react-router-dom";
 import { motion } from "framer-motion";
-import { BiSolidUpvote } from "react-icons/bi";
+import { BiEdit, BiSolidUpvote, BiTrash } from "react-icons/bi";
 import { useUpvote } from "../hooks/useUpvote";
+import { useDeletePost } from "../hooks/useDeletePost";
 
 interface UserProfile {
   name: string;
@@ -45,6 +46,7 @@ const Profile = () => {
   const navigate = useNavigate();
   const { state } = useLocation();
   const { username } = useParams();
+  const { deletePost } = useDeletePost();
 
   // Fetch userId if not in state
   useEffect(() => {
@@ -106,6 +108,10 @@ const Profile = () => {
     );
   }
 
+  const handleDelete = (postId:number) => {
+    deletePost(postId, () => navigate('/feed'));
+  };
+
   const joinedDate = new Date(profile.createdAt).toLocaleDateString();
 
   return (
@@ -162,6 +168,33 @@ const Profile = () => {
                     </IconButton>
                   </motion.div>
                   <Badge colorScheme="blue" size="lg">{post.upvotes}</Badge>
+                  {(post.author?.username === user?.username) && (
+                  <>
+                    <IconButton
+                      size="md"
+                      aria-label="Edit"
+                      variant='ghost'
+                      color={'blue.500'}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        navigate(`/edit/${post.id}`, { state: { post } });
+                      }}
+                    >  
+                      <BiEdit />
+                    </IconButton><IconButton
+                      size="md"
+                      aria-label="Delete"
+                      variant='ghost'
+                      color={'red'}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleDelete(post.id);
+                      }}
+                    >  
+                      <BiTrash/>
+                    </IconButton>
+                  </>
+                )}
                 </Stack>
               </Box>
             </motion.div>


### PR DESCRIPTION
This PR introduces edit and delete functionality for user-authored posts directly from their profile page. The profile component now conditionally renders edit and delete buttons beside each post when the logged-in user is viewing their own profile. The same delete handler from the feed is reused, and navigate is used for routing to the edit post page.