### PR TITLE
Implement frontend and backend logic for editable bio on profile

### DIFF
--- a/apps/backend/src/routes/profile.ts
+++ b/apps/backend/src/routes/profile.ts
@@ -94,6 +94,36 @@ router.put('/profile/:id/password', async (req, res) => {
   }
 });
 
+
+router.put('/profile/:id/update-bio', async (req, res) => {
+  const { id } = req.params;
+  const {updatedBio}  = req.body;
+  if (typeof updatedBio !== "string") {
+    res.status(400).json({ error: "Bio must be a string" });
+    return 
+  }
+
+  try {
+    const user = await prisma.user.findUnique({ where: { id } });
+
+    if (!user) {
+      res.status(404).json({ error: "User not found" });
+      return 
+    }
+
+    const updatedUser = await prisma.user.update({
+      where: { id },
+      data: { bio: updatedBio },
+    });
+
+    res.status(200).json({ message: "Bio updated successfully", user: updatedUser });
+  } catch (err) {
+    console.error("Error updating bio:", err);
+    res.status(500).json({ error: "Internal server error" });
+  }
+});
+
+
 router.get('/profile/username-to-id/:username', async (req, res) => {
   const { username } = req.params;
   try {

--- a/apps/frontend/src/pages/Profile.tsx
+++ b/apps/frontend/src/pages/Profile.tsx
@@ -118,22 +118,20 @@ const Profile = () => {
 
   const handleSaveBio = async () => {
     if (!editedBio.trim() || !userId) return;
-
     try {
       const response = await fetch(`http://localhost:3001/api/profile/${userId}/update-bio`, {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ bio: editedBio }),
+        body: JSON.stringify({ updatedBio: editedBio }),
       });
 
       if (!response.ok) {
         throw new Error("Failed to update bio");
       }
 
-      const updatedProfile = await response.json();
-      setProfile(updatedProfile);
+      profile.bio = editedBio;
       setIsEditingBio(false);
     } catch (error) {
       console.error("Error updating bio:", error);


### PR DESCRIPTION
This PR introduces the full functionality to allow users to update their bio on the profile page. It includes both frontend and backend logic. Users can now see their bio along with an edit button (if viewing their own profile). On clicking edit, a text field appears allowing them to modify and save the bio. The updated bio is then persisted via a PUT request to the backend and immediately reflected in the UI.