### PR TITLE
Added API to allow users to comment on posts

### DIFF
--- a/apps/backend/src/index.ts
+++ b/apps/backend/src/index.ts
@@ -4,7 +4,7 @@ import authRoutes from './routes/auth';
 import postRoutes from './routes/posts';
 import profileRoutes from './routes/profile';
 import userRoutes from './routes/users'
-
+import commentRoutes from './routes/comments'
 
 const app = express();
 const PORT = 3001;
@@ -16,6 +16,7 @@ app.use('/api', authRoutes); // Mount auth routes
 app.use('/api', postRoutes);
 app.use('/api',profileRoutes);
 app.use('/api',userRoutes);
+app.use('/api',commentRoutes);
 
 app.get('/', (_req, res) => {
   res.send('API is running...');

--- a/apps/backend/src/routes/comments.ts
+++ b/apps/backend/src/routes/comments.ts
@@ -1,0 +1,35 @@
+// routes/comments.ts
+import express from 'express';
+import { PrismaClient } from '@prisma/client';
+
+const prisma = new PrismaClient();
+const router = express.Router();
+
+// ✅ Add a comment to a post
+router.post('/post/:postId/comments', async (req, res) => {
+  const { postId } = req.params;
+  const { content, authorId } = req.body;
+
+  if (!content || !authorId) {
+    res.status(400).json({ error: 'Missing content or authorId' });
+    return;
+  }
+
+  try {
+    const comment = await prisma.comment.create({
+      data: {
+        content,
+        postId: parseInt(postId),
+        authorId,
+      },
+      include: { author: true },
+    });
+    res.status(201).json(comment);
+  } catch (error) {
+    console.error('Error creating comment:', error);
+    res.status(500).json({ error: 'Failed to create comment' });
+  }
+});
+
+
+export default router;


### PR DESCRIPTION
This PR introduces the foundational backend support for a comment system by adding an API to create comments on individual posts. It includes:
A dedicated endpoint to allow authenticated users to add comments to any post
This is the first step toward enabling community interactions on the platform through threaded conversations under posts.