### PR TITLE
Display comment count for each post in feed page

### DIFF
--- a/apps/backend/src/routes/comments.ts
+++ b/apps/backend/src/routes/comments.ts
@@ -56,7 +56,7 @@ router.get('/post/:postId/comments/count', async (req, res) => {
     const count = await prisma.comment.count({
       where: { postId: parseInt(postId) },
     });
-
+    console.log(`PostId: ${postId}, Count: ${count}`);
     res.json({ count });
   } catch (error) {
     console.error('Error fetching comment count:', error);


### PR DESCRIPTION
Integrated backend API to fetch number of comments per post.

Enhanced the feed UI by showing the comment count beside the comment icon.

Modified post fetching logic to append comment counts.

Ensured fallback for failed comment count requests.