### PR TITLE
Add Back Button Navigation to Post Detail Page

### DIFF
--- a/apps/frontend/src/pages/PostDetail.tsx
+++ b/apps/frontend/src/pages/PostDetail.tsx
@@ -7,8 +7,9 @@ import {
   IconButton,
   Badge,
   Spinner,
+  Flex,
 } from "@chakra-ui/react";
-import { BiSolidUpvote,BiEdit,BiTrash } from "react-icons/bi";
+import { BiSolidUpvote,BiEdit,BiTrash,BiArrowBack } from "react-icons/bi";
 import { useEffect, useState } from "react";
 import { useParams,useNavigate } from "react-router-dom";
 import { useUpvote } from '../hooks/useUpvote';
@@ -101,6 +102,21 @@ const PostDetail = () => {
 
   return (
     <Box maxW="xl" mx="auto" mt={10} p={6} bg="white" rounded="md" shadow="md">
+      {/* Back Button and Title in Same Line */}
+      <Flex align="center" mb={6}>
+        <IconButton
+          variant="ghost"
+          onClick={() => navigate('/feed')}
+          aria-label="Back to Feed"
+          mr={3}
+        >
+          <BiArrowBack />
+        </IconButton>
+        <Heading size="lg" color="teal.600">
+          Post Details
+        </Heading>
+      </Flex>
+
       {/* Title & Avatar */}
       <Stack direction="row" align="center" spaceX={4} mb={4}>
         {post.author.avatar ? (


### PR DESCRIPTION
Enhanced the post detail page navigation by adding a back button positioned inline with the page header. This completes the consistent navigation pattern across all detail pages in the application.

Changes:
- Added back button to post detail page header
- Positioned back button inline with "Post Details" title using Flex layout
- Implemented IconButton with BiArrowBack icon for consistent design
- Added proper spacing and accessibility attributes
- Maintained consistent navigation behavior redirecting to feed page