### PR TITLE
Show relative time format on feed posts

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -13,6 +13,7 @@
     "@chakra-ui/react": "^3.21.0",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
+    "date-fns": "^4.1.0",
     "framer-motion": "^12.19.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",

--- a/apps/frontend/src/pages/Feed.tsx
+++ b/apps/frontend/src/pages/Feed.tsx
@@ -15,6 +15,7 @@ import { motion } from 'framer-motion';
 import Navbar from '../components/Navbar';
 import PostActions from '../components/PostActions';
 import { TbArrowBigLeftLine,TbArrowBigRightLine } from "react-icons/tb";
+import { formatDistanceToNow } from 'date-fns';
 
 interface Post {
   id: number;
@@ -158,7 +159,7 @@ const Feed = () => {
                     <Text mb={3}>{post.content}</Text>
                     <Stack direction="row" justify="space-between" fontSize="sm" color="gray.500">
                       <Text>by {post.author?.username}</Text>
-                      <Text>{new Date(post.updatedAt).toLocaleString()}</Text>
+                      <Text>{formatDistanceToNow(new Date(post.updatedAt), { addSuffix: true })}</Text>
                     </Stack>
                     <Box mt={3}>
                       <PostActions


### PR DESCRIPTION
Replaced static timestamp with relative time formatting using date-fns.
Now displays post update times like "3 hours ago" or "2 days ago" instead of full datetime strings.
Improves readability and provides a more intuitive user experience.