### PR TITLE
Show relative time on profile page posts

### DIFF
--- a/apps/frontend/src/pages/Profile.tsx
+++ b/apps/frontend/src/pages/Profile.tsx
@@ -18,6 +18,7 @@ import { BiEdit, BiArrowBack } from "react-icons/bi";
 import { useDeletePost } from "../hooks/useDeletePost";
 import { toaster } from "../components/ui/toaster";
 import PostActions from "../components/PostActions"; // Import the PostActions component
+import { formatDistanceToNow } from 'date-fns';
 
 interface UserProfile {
   name: string;
@@ -276,7 +277,7 @@ const Profile = () => {
                 <Text mb={3}>{post.content}</Text>
                 <Stack direction="row" justify="space-between" fontSize="sm" color="gray.500">
                   <Text>by {post.author?.username}</Text>
-                  <Text>{new Date(post.updatedAt).toLocaleString()}</Text>
+                  <Text>{formatDistanceToNow(new Date(post.updatedAt), { addSuffix: true })}</Text>
                 </Stack>
 
                 {/* Replace the entire actions section with PostActions component */}

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,6 +44,7 @@
         "@chakra-ui/react": "^3.21.0",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
+        "date-fns": "^4.1.0",
         "framer-motion": "^12.19.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
@@ -3576,6 +3577,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.1",


### PR DESCRIPTION
Replaced absolute timestamps on profile posts with relative time (e.g., "2 days ago").
Utilizes formatDistanceToNow from date-fns for consistency across the app.
Improves readability and aligns time display with the feed page format.