### PR TITLE
fix: Resolve Prisma select/include conflict in post detail query

### DIFF
--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -252,22 +252,29 @@ router.get('/posts/:id/detail', async (req, res) => {
   try {
     const post = await prisma.post.findUnique({
       where: { id: postId },
-      include: {
-        author: {
-          select: { username: true, avatar: true }
-        }
-      },
-      select: { // 👈 Explicitly select fields, including mediaUrl
+      // REMOVED 'include' block
+      select: { // Combined all desired fields and relations here
         id: true,
         title: true,
         content: true,
-        mediaUrl: true, // Make sure mediaUrl is selected
+        mediaUrl: true,
         createdAt: true,
         updatedAt: true,
         upvotes: true,
-        author: {
+        author: { // Select specific fields from the author relation
           select: { username: true, avatar: true }
-        }
+        },
+        // If you wanted to include comments here, you would add:
+        // comments: {
+        //   select: {
+        //     id: true,
+        //     content: true,
+        //     createdAt: true,
+        //     author: {
+        //       select: { username: true, avatar: true }
+        //     }
+        //   }
+        // }
       }
     });
 


### PR DESCRIPTION
This PR addresses a TypeScript error in the `/api/posts/:id/detail` endpoint caused by using both `select` and `include` in a single Prisma query.

The Prisma query for fetching post details has been refactored to use a single `select` block, correctly specifying all desired fields, including nested author details. This ensures the API endpoint functions as expected and provides accurate post data.
