### PR TITLE
Fix: Resolve post deletion

### DIFF
--- a/apps/backend/src/routes/posts.ts
+++ b/apps/backend/src/routes/posts.ts
@@ -219,12 +219,18 @@ router.delete('/posts/:id', async (req, res) => {
   const postId = Number(req.params.id);
   console.log("in delete req handler")
   try {
+    // First, delete all comments associated with the post
+    await prisma.comment.deleteMany({
+      where: { postId: postId },
+    });
+
     // Optional: Fetch the post first to get mediaUrl and delete the file from disk
     const postToDelete = await prisma.post.findUnique({
       where: { id: postId },
       select: { mediaUrl: true }
     });
 
+    // Now, delete the post
     await prisma.post.delete({
       where: { id: postId },
     });


### PR DESCRIPTION
This pull request addresses a critical bug that prevented users from deleting posts that had associated comments. The issue was caused by a database constraint violation. The fix updates the backend delete logic to first remove all dependent comments from the database before deleting the post itself, ensuring data integrity and allowing for successful post removal.