### PR TITLE
Feat: Add notification support for upvotes

### DIFF
--- a/apps/frontend/src/components/NotificationPanel.tsx
+++ b/apps/frontend/src/components/NotificationPanel.tsx
@@ -34,7 +34,7 @@ const NotificationPanel = ({ notifications }: NotificationPanelProps) => {
             // Each notification links to the specific post
             <ChakraLink 
               as={RouterLink} 
-              // to={`/post/${notif.post.id}`} 
+              to={`/post/${notif.post.id}`} 
               key={notif.id} 
               _hover={{ textDecoration: 'none' }}
             >
@@ -54,7 +54,7 @@ const NotificationPanel = ({ notifications }: NotificationPanelProps) => {
                   <Text as="span" fontWeight="bold">{notif.sender.username}</Text>
                   {notif.type === 'NEW_COMMENT'
                     ? ` commented on your post "${notif.post.title}".`
-                    : ' upvoted your post.'}
+                    : ` upvoted your post "${notif.post.title}".`}
                 </Text>
               </Flex>
             </ChakraLink>

--- a/apps/frontend/src/hooks/useUpvote.ts
+++ b/apps/frontend/src/hooks/useUpvote.ts
@@ -1,5 +1,10 @@
 // src/hooks/useUpvote.ts
+import { useAuth } from '../context/AuthContext';
+import { toaster } from '../components/ui/toaster';
+
 export const useUpvote = () => {
+  const { user } = useAuth(); // Get the logged-in user
+
   const hasUpvoted = (postId: number) => {
     return localStorage.getItem(`upvoted_${postId}`) === 'true';
   };
@@ -9,12 +14,21 @@ export const useUpvote = () => {
     currentUpvotes: number,
     setPostState: (upvotes: number) => void
   ) => {
+    if (!user) {
+      toaster.create({ title: 'You must be logged in to vote', type: 'error' });
+      return;
+    }
+
     const localKey = `upvoted_${postId}`;
     const hasVoted = hasUpvoted(postId);
     try {
       const res = await fetch(
         `http://localhost:3001/api/posts/${postId}/${hasVoted ? 'unvote' : 'upvote'}`,
-        { method: 'POST' }
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: user.id }), // ✨ Send the user's ID
+        }
       );
 
       if (!res.ok) throw new Error();


### PR DESCRIPTION
This PR extends the notification system to include upvotes.

Backend: The /posts/:id/upvote route now creates a NEW_UPVOTE notification for the post's author when a user upvotes their post.

Frontend: The useUpvote hook has been updated to send the authenticated user's ID in the request body, which is necessary for creating the notification.

UI: The NotificationPanel has been updated to display a distinct message for upvote notifications, including the title of the post that was upvoted.