### PR TITLE
Feat: Implement soft-delete logic for notifications

### DIFF
--- a/apps/backend/prisma/migrations/20250727094533_add_cleared_flag_to_notifications/migration.sql
+++ b/apps/backend/prisma/migrations/20250727094533_add_cleared_flag_to_notifications/migration.sql
@@ -1,0 +1,21 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Notification" (
+    "id" INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+    "postId" INTEGER NOT NULL,
+    "recipientId" TEXT NOT NULL,
+    "senderId" TEXT NOT NULL,
+    "type" TEXT NOT NULL,
+    "read" BOOLEAN NOT NULL DEFAULT false,
+    "isCleared" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "Notification_postId_fkey" FOREIGN KEY ("postId") REFERENCES "Post" ("id") ON DELETE CASCADE ON UPDATE CASCADE,
+    CONSTRAINT "Notification_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Notification_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Notification" ("createdAt", "id", "postId", "read", "recipientId", "senderId", "type") SELECT "createdAt", "id", "postId", "read", "recipientId", "senderId", "type" FROM "Notification";
+DROP TABLE "Notification";
+ALTER TABLE "new_Notification" RENAME TO "Notification";
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -46,11 +46,12 @@ model Notification {
   post        Post             @relation(fields: [postId], references: [id], onDelete: Cascade)
   postId      Int
   recipient   User             @relation("Recipient", fields: [recipientId], references: [id])
-  recipientId String // <-- Changed from Int to String
+  recipientId String
   sender      User             @relation("Sender", fields: [senderId], references: [id])
-  senderId    String // <-- Changed from Int to String
+  senderId    String
   type        NotificationType
   read        Boolean          @default(false)
+  isCleared   Boolean          @default(false)
   createdAt   DateTime         @default(now())
 }
 

--- a/apps/backend/src/routes/notifications.ts
+++ b/apps/backend/src/routes/notifications.ts
@@ -10,7 +10,10 @@ router.get('/notifications/:userId', async (req, res) => {
 
   try {
     const notifications = await prisma.notification.findMany({
-      where: { recipientId: userId },
+      where: { 
+        recipientId: userId,
+        isCleared: false
+      },
       orderBy: { createdAt: 'desc' },
       include: {
         // Include details about the user who sent the notification


### PR DESCRIPTION
This PR creates a soft delete notification system

Schema: 
The Notification model has been updated with an isCleared boolean flag to track the notification's visibility state.

Backend API:
The GET /api/notifications endpoint now filters out notifications that have been cleared.
A new POST /api/notifications/clear-all endpoint has been added to mark all of a user's notifications as cleared.

Frontend Hook: 
The clearAllNotifications function in the useNotifications hook has been updated to call the new clear-all endpoint.