### PR TITLE
Feat: Add clear all button to notification panel

### DIFF
--- a/apps/frontend/src/components/Navbar.tsx
+++ b/apps/frontend/src/components/Navbar.tsx
@@ -28,7 +28,7 @@ const Navbar = () => {
   const [isLoggingOut, setIsLoggingOut] = useState(false);
 
   // ✨ NEW: Notification state and logic
-  const { notifications, unreadCount, markAsRead } = useNotifications();
+  const { notifications, unreadCount, markAsRead, clearAllNotifications } = useNotifications();
   const [isPanelOpen, setIsPanelOpen] = useState(false);
 
   const handleBellClick = () => {
@@ -180,7 +180,7 @@ const Navbar = () => {
               )}
 
               {isPanelOpen && (
-                <NotificationPanel notifications={notifications} />
+                <NotificationPanel notifications={notifications} onClearAll={clearAllNotifications}  />
               )}
             </Box>
 

--- a/apps/frontend/src/components/NotificationPanel.tsx
+++ b/apps/frontend/src/components/NotificationPanel.tsx
@@ -1,14 +1,23 @@
 // apps/frontend/src/components/NotificationPanel.tsx
-import { Box, Text, VStack, Link as ChakraLink, Image, Flex } from '@chakra-ui/react';
+import 
+{ Box, 
+  Text, 
+  VStack, 
+  Link as ChakraLink, 
+  Image, 
+  Flex,
+  IconButton
+}   from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
-import type { Notification } from '../hooks/useNotifications'; // Assuming your hook and types are set up
- // Assuming your hook and types are set up
+import type { Notification } from '../hooks/useNotifications'; 
+import { BiX } from 'react-icons/bi';
 
 interface NotificationPanelProps {
   notifications: Notification[];
+  onClearAll: () => void;
 }
 
-const NotificationPanel = ({ notifications }: NotificationPanelProps) => {
+const NotificationPanel = ({ notifications, onClearAll }: NotificationPanelProps) => {
   return (
     <Box
       position="absolute"
@@ -24,42 +33,60 @@ const NotificationPanel = ({ notifications }: NotificationPanelProps) => {
       boxShadow="lg"
       zIndex={20} // Ensure it appears above other content
     >
+      <Flex justify="space-between" align="center" p={2} borderBottom="1px solid" borderColor="gray.200">
+        <Text fontWeight="bold" fontSize="md" ml={2}>Notifications</Text>
+        {/* Only show the button if there are notifications to clear */}
+        {notifications.length > 0 && (
+            <IconButton
+              aria-label="Clear all notifications"
+              size="xs"
+              variant="ghost"
+              onClick={onClearAll} // Call the function passed via props
+            >
+              <BiX />
+            </IconButton>  
+        )}
+      </Flex>
       <VStack align="stretch">
         {notifications.length === 0 ? (
           <Text p={4} fontSize="sm" color="gray.500">
             You have no new notifications.
           </Text>
         ) : (
-          notifications.map((notif) => (
+          notifications.map((notif) => {
             // Each notification links to the specific post
-            <ChakraLink 
-              as={RouterLink} 
-              to={`/post/${notif.post.id}`} 
-              key={notif.id} 
-              _hover={{ textDecoration: 'none' }}
-            >
-              <Flex
-                p={3}
-                align="center"
-                borderBottom="1px solid"
-                borderColor="gray.100"
-                bg={!notif.read ? 'teal.50' : 'transparent'} // Highlight unread notifications
-                _hover={{ bg: 'gray.100' }}
-                transition="background-color 0.2s"
+            if (!notif.post || !notif.sender) {
+              return null;
+            }
+            return(
+              <ChakraLink 
+                as={RouterLink} 
+                to={`/post/${notif.post.id}`} 
+                key={notif.id} 
+                _hover={{ textDecoration: 'none' }}
               >
-                <Image src={notif.sender.avatar} boxSize="50px"
-                        borderRadius="full"
-                        fit="cover"/>
-                <Text ml={3} fontSize="sm">
-                  <Text as="span" fontWeight="bold">{notif.sender.username}</Text>
-                  {notif.type === 'NEW_COMMENT'
-                    ? ` commented on your post "${notif.post.title}".`
-                    : ` upvoted your post "${notif.post.title}".`}
-                </Text>
-              </Flex>
-            </ChakraLink>
-          ))
-        )}
+                <Flex
+                  p={3}
+                  align="center"
+                  borderBottom="1px solid"
+                  borderColor="gray.100"
+                  bg={!notif.read ? 'teal.50' : 'transparent'} // Highlight unread notifications
+                  _hover={{ bg: 'gray.100' }}
+                  transition="background-color 0.2s"
+                >
+                  <Image src={notif.sender.avatar} boxSize="50px"
+                          borderRadius="full"
+                          fit="cover"/>
+                  <Text ml={3} fontSize="sm">
+                    <Text as="span" fontWeight="bold">{notif.sender.username}</Text>
+                    {notif.type === 'NEW_COMMENT'
+                      ? ` commented on your post "${notif.post.title}".`
+                      : ` upvoted your post "${notif.post.title}".`}
+                  </Text>
+                </Flex>
+              </ChakraLink>
+          )}
+        ))}
       </VStack>
     </Box>
   );

--- a/apps/frontend/src/hooks/useNotifications.ts
+++ b/apps/frontend/src/hooks/useNotifications.ts
@@ -49,6 +49,23 @@ export const useNotifications = () => {
     }
   };
 
+  const clearAllNotifications = async () => {
+    if (!user || notifications.length === 0) return;
+    try {
+      // ✨ UPDATED: Change to a POST request to the new endpoint
+      await fetch('http://localhost:3001/api/notifications/clear-all', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userId: user.id }),
+      });
+      // The local state update remains the same for instant UI feedback
+      setNotifications([]);
+      setUnreadCount(0);
+    } catch (error) {
+      console.error('Failed to clear notifications:', error);
+    }
+  };
+
   useEffect(() => {
     fetchNotifications();
 
@@ -58,5 +75,5 @@ export const useNotifications = () => {
     return () => clearInterval(interval); // Cleanup on component unmount
   }, [user]);
 
-  return { notifications, unreadCount, markAsRead };
+  return { notifications, unreadCount, markAsRead, clearAllNotifications };
 };


### PR DESCRIPTION
This PR completes the soft-delete notification feature by adding the final UI element.

A "Clear All" (X) button has been added to the header of the NotificationPanel.

The button is only visible when there are notifications to clear.

Clicking the button triggers the clearAllNotifications function from the useNotifications hook, which soft-deletes the notifications on the backend and clears them from the UI.