### PR TITLE
Fix: Notifications reappear on reload after being cleared

### DIFF
--- a/apps/backend/src/routes/notifications.ts
+++ b/apps/backend/src/routes/notifications.ts
@@ -59,4 +59,24 @@ router.post('/notifications/mark-as-read', async (req, res) => {
   }
 });
 
+// Handle "clear all" request from the frontend
+router.post('/notifications/clear-all', async (req, res) => {
+  const { userId } = req.body;
+
+  try {
+    await prisma.notification.updateMany({
+      where: {
+        recipientId: userId,
+      },
+      data: {
+        isCleared: true, // Set the cleared flag to true
+      },
+    });
+    res.status(200).json({ message: 'All notifications cleared' });
+  } catch (error)    {
+    console.error('Error clearing notifications:', error);
+    res.status(500).json({ error: 'Failed to clear notifications' });
+  }
+});
+
 export default router;


### PR DESCRIPTION
This PR resolves a critical bug where cleared notifications would reappear after the user reloaded the page.

Root Cause: The backend was missing the /api/notifications/clear-all endpoint, causing the clear request to fail silently. 
The missing POST /api/notifications/clear-all route has been added to the backend to correctly handle the soft-delete request.