### PR TITLE
Fix: Separate notification count from display list for accuracy

### DIFF
--- a/apps/frontend/src/components/NotificationPanel.tsx
+++ b/apps/frontend/src/components/NotificationPanel.tsx
@@ -1,4 +1,3 @@
-// apps/frontend/src/components/NotificationPanel.tsx
 import 
 { Box, 
   Text, 
@@ -6,7 +5,7 @@ import
   Link as ChakraLink, 
   Image, 
   Flex,
-  IconButton
+  IconButton,
 }   from '@chakra-ui/react';
 import { Link as RouterLink } from 'react-router-dom';
 import type { Notification } from '../hooks/useNotifications'; 
@@ -88,6 +87,19 @@ const NotificationPanel = ({ notifications, onClearAll }: NotificationPanelProps
           )}
         ))}
       </VStack>
+      <ChakraLink
+        as={RouterLink}
+        to="/notifications"
+        fontWeight="bold"
+        color="blue.500"
+        textAlign="center"
+        p={2}
+        display="block"
+        fontSize="sm"
+        _hover={{ bg: 'gray.100' }}
+      >
+        Show All
+      </ChakraLink>
     </Box>
   );
 };


### PR DESCRIPTION
This PR resolves a logical bug where the unread notification badge on the bell icon was incorrectly limited by the number of notifications displayed in the panel.

Backend:

A new, efficient endpoint (/unread-count) has been created to exclusively fetch the total unread notification count.

The primary (/notifications/:userId) endpoint has been enhanced to accept a limit query parameter, making it more flexible for different UI components.

Frontend:

The useNotifications hook has been refactored to make two parallel API calls: one for the accurate total count (for the badge) and another for the limited list of recent notifications (for the panel).